### PR TITLE
Respect http proxy settings when using custom Transport

### DIFF
--- a/pkg/getter/httpgetter.go
+++ b/pkg/getter/httpgetter.go
@@ -76,6 +76,7 @@ func newHTTPGetter(URL, CertFile, KeyFile, CAFile string) (Getter, error) {
 		client.client = &http.Client{
 			Transport: &http.Transport{
 				TLSClientConfig: tlsConf,
+				Proxy: http.ProxyFromEnvironment,
 			},
 		}
 	} else {


### PR DESCRIPTION
The custom http client used when client certs are provided should respect https_proxy, http_proxy, and no-proxy if they are set in the environment, the same way that the default client does.